### PR TITLE
[11.x] Add method to return object in collection

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -952,6 +952,16 @@ trait EnumeratesValues
     }
 
     /**
+     * Get the collection of items as Object.
+     *
+     * @return object|null
+     */
+    public function toObject()
+    {
+        return json_decode($this->toJson(), false);
+    }
+
+    /**
      * Get a CachingIterator instance.
      *
      * @param  int  $flags


### PR DESCRIPTION
Example:

````PHP
$collection = collect(['name' => 'Desk', 'price' => 100]);

$collection->toArray();
/*
['name' => 'Desk', 'price' => 100]
*/

$collection->toObject();
/*
{
name: 'Desk',
price: 100
}
*/